### PR TITLE
version bump. fixes vue namespace error in declaration file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-property-decorator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -71,9 +71,9 @@
       }
     },
     "@types/node": {
-      "version": "7.0.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.43.tgz",
-      "integrity": "sha512-7scYwwfHNppXvH/9JzakbVxk0o0QUILVk1Lv64GRaxwPuGpnF1QBiwdvhDpLcymb8BpomQL3KYoWKq3wUdDMhQ==",
+      "version": "7.0.56",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.56.tgz",
+      "integrity": "sha512-NgjN3xPyqbAXSIpznNAR5Cisx5uKqJWxcS9kefzSFEX/9J7O01/FHyfnvPI7SztBf9p6c8mqOn3olZWJx3ja6g==",
       "dev": true
     },
     "ansi-align": {
@@ -2334,15 +2334,6 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
-    "nuxt-class-component": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/nuxt-class-component/-/nuxt-class-component-1.0.3.tgz",
-      "integrity": "sha512-Lo43E6sxbHOgdmuXOMoQjfRPcB/8C6MHoDNiNHlKwkHjEwRkkls7jWf12D/frg2hm6s2S6dhbHOVzwTowU/18w==",
-      "requires": {
-        "vue": "2.4.2",
-        "vue-class-component": "5.0.2"
-      }
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2800,9 +2791,9 @@
       }
     },
     "reflect-metadata": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz",
-      "integrity": "sha1-tPg3BEFqytiZiMmxVjXUfgO5NEo="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
     },
     "regenerate": {
       "version": "1.3.2",
@@ -3080,15 +3071,6 @@
       "integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3114,6 +3096,15 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -3286,9 +3277,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "uid2": {
@@ -3365,14 +3356,10 @@
       }
     },
     "vue": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.4.2.tgz",
-      "integrity": "sha512-GB5r+CsrCHIB1PoXt4wgBienjF3WGYOIaTK27tDk96sZxpL5RwRrsi9I3ECwFt8x8qAmxT2xk1vsY2Vpcn9nIw=="
-    },
-    "vue-class-component": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-5.0.2.tgz",
-      "integrity": "sha512-wgI/SKRozqADIeMGN16PXiHBa/cnRD7JcuYt7P4JHcMIMc2BdUw02pQ+EQmsui0tN2kRVZGwZ8h4Yb2Vbf4w0w=="
+      "version": "2.5.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.15.tgz",
+      "integrity": "sha512-uUcDI147VCQYA/9AqoEECddWdTQgrhnwAd6KDsl0pF1hiLpxqaYqIgArhnegU+QZ18DQrKvZNcR3x2QM1iaroQ==",
+      "dev": true
     },
     "which": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -24,16 +24,16 @@
     "lib"
   ],
   "devDependencies": {
-    "@types/node": "^7.0.5",
+    "@types/node": "^7.0.56",
     "ava": "^0.19.1",
     "rollup": "^0.45.2",
-    "typescript": "^2.4.1",
-    "vue": "^2.2.1"
+    "typescript": "^2.7.2",
+    "vue": "^2.5.15"
   },
   "typings": "./lib/nuxt-property-decorator.d.ts",
   "dependencies": {
-    "reflect-metadata": "^0.1.9",
-    "vue-class-component": "^5.0.2"
+    "reflect-metadata": "^0.1.12",
+    "vue-class-component": "^6.0.2"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2745,9 +2745,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-vue-class-component@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-5.0.0.tgz#6cc52502fa40a05100ffc4cf2dfa3a3f849b8e0b"
+vue-class-component@^6.0.2:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-6.2.0.tgz#7adb1daa9a868c75f30f97f33f4f1b94aee62089"
 
 vue@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
This resolves an error in an earlier version of vue-class-component's declaration file.

'Vue' only refers to a type, but is being used as a namespace here